### PR TITLE
chore(dx): complete intermediate nan baseline rollout

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -84,4 +84,6 @@ jobs:
 
       - name: Skip non-Dependabot PR
         if: steps.pr.outputs.number != '' && steps.author.outputs.is_dependabot != 'true'
-        run: echo "PR #${{ steps.pr.outputs.number }} is not from Dependabot; skipping."
+        run: |
+          pr_num="${{ steps.pr.outputs.number }}"
+          echo "PR #$pr_num is not from Dependabot; skipping."

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@
 
 # Default target
 help:
-
 	@echo ""
 	@echo "🚀 AWS Glue ETL Boilerplate"
 	@echo "=================================================="
@@ -38,7 +37,7 @@ help:
 	@echo "🧪 Testing & Quality:"
 	@echo "  test            - Run all tests (unit + integration)"
 	@echo "  test-unit       - Run unit tests only"
-	@echo "  test-integration- Run integration tests only"
+	@echo "  test-integration - Run integration tests only"
 	@echo "  test-coverage   - Run tests with coverage report"
 	@echo "  lint            - Run code linting with Ruff"
 	@echo "  type-check      - Run mypy on core boilerplate modules"
@@ -68,21 +67,6 @@ help:
 	@echo "  scaffold-source SOURCE=<source> [ENTITY_TYPE=<type>] - Generate raw/bronze/silver/gold job templates"
 	@echo "   Example: make run-raw DATA_SOURCE=public_api ENTITY_TYPE=posts"
 	@echo "   Example: make scaffold-source SOURCE=crm_api ENTITY_TYPE=customers"
-	@echo ""
-	@echo "🧪 Testing & Quality:"
-	@echo "  test            - Run all tests (unit + integration)"
-	@echo "  test-unit       - Run unit tests only"
-	@echo "  test-integration- Run integration tests only"
-	@echo "  test-coverage   - Run tests with coverage report"
-	@echo "  lint            - Run code linting with Ruff"
-	@echo "  type-check      - Run mypy on core boilerplate modules"
-	@echo "  format          - Format code with black"
-	@echo "  autofix         - Auto-fix code formatting and imports"
-	@echo ""
-	@echo "🗃️  Database Migrations:"
-	@echo "  migrate         - Run database migrations (local environment)"
-	@echo "  migrate-upload  - Upload migration files to S3 (LocalStack)"
-	@echo "  migrate-dry-run - Show migration configuration without executing"
 	@echo ""
 	@echo "📦 Packaging & Deployment:"
 	@echo "  package         - Build standard package (wheels + ZIP)"
@@ -168,35 +152,15 @@ validate:
 
 # Validate project environment plus optional NaNLABS checks
 check-env: validate
-	@echo ""
-	@echo "🔎 Optional NaNLABS environment check..."
-	@if command -v nan-doctor >/dev/null 2>&1; then \
-		nan-doctor; \
-	else \
-		echo "ℹ️ nan-doctor not found; skipping optional baseline check."; \
-	fi
+	@./scripts/nan-baseline.sh doctor
 
 # Run optional NaNLABS workstation checks without blocking contributors
 nan-health:
-	@echo "🩺 Running optional NaNLABS checks..."
-	@if command -v nan-doctor >/dev/null 2>&1; then \
-		nan-doctor; \
-	else \
-		echo "ℹ️ nan-doctor not found; skipping."; \
-	fi
-	@if command -v nan-update-check >/dev/null 2>&1; then \
-		nan-update-check; \
-	else \
-		echo "ℹ️ nan-update-check not found; skipping."; \
-	fi
+	@./scripts/nan-baseline.sh health
 
 # List available NaNLABS skills when baseline is installed
 nan-skills:
-	@if command -v nan-skills >/dev/null 2>&1; then \
-		nan-skills list; \
-	else \
-		echo "ℹ️ nan-skills not found; skipping."; \
-	fi
+	@./scripts/nan-baseline.sh skills
 
 # Check status of all services
 services-status:

--- a/scripts/nan-baseline.sh
+++ b/scripts/nan-baseline.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper for optional NaNLABS baseline commands.
+# Exit code contract:
+# - 0: command completed or optional command not available.
+# - non-zero: command failed and strict mode is enabled.
+
+log() {
+  printf '[nan-baseline] %s\n' "$1"
+}
+
+run_optional() {
+  local cmd="$1"
+  shift || true
+
+  if command -v "$cmd" >/dev/null 2>&1; then
+    log "running: $cmd $*"
+    if "$cmd" "$@"; then
+      log "ok: $cmd"
+    else
+      local rc=$?
+      if [ "${NAN_BASELINE_STRICT:-0}" = "1" ]; then
+        log "error: $cmd failed with exit code $rc (strict mode)"
+        return "$rc"
+      fi
+      log "warn: $cmd failed with exit code $rc (non-strict mode, continuing)"
+    fi
+  else
+    log "skip: $cmd not found"
+  fi
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./scripts/nan-baseline.sh doctor
+  ./scripts/nan-baseline.sh update
+  ./scripts/nan-baseline.sh skills
+  ./scripts/nan-baseline.sh health
+
+Commands:
+  doctor  Run nan-doctor if installed.
+  update  Run nan-update-check if installed.
+  skills  Run nan-skills list if installed.
+  health  Run doctor + update in sequence.
+
+Environment:
+  NAN_BASELINE_STRICT=1  Fail if an optional command exists but returns non-zero.
+EOF
+}
+
+main() {
+  local action="${1:-}"
+
+  case "$action" in
+    doctor)
+      run_optional nan-doctor
+      ;;
+    update)
+      run_optional nan-update-check
+      ;;
+    skills)
+      run_optional nan-skills list
+      ;;
+    health)
+      run_optional nan-doctor
+      run_optional nan-update-check
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Completes the pending intermediate rollout items for NaNLABS baseline adoption in this repository.

## Changelog

- Added `scripts/nan-baseline.sh` as a standardized wrapper for optional baseline checks.
- Standardized baseline command output prefix and behavior (`[nan-baseline]`).
- Added non-strict by default execution for optional checks, with strict mode support via `NAN_BASELINE_STRICT=1`.
- Refactored `Makefile` baseline targets to use the wrapper (`check-env`, `nan-health`, `nan-skills`).
- Cleaned `make help` output by removing duplicated sections and fixing command labels.

## Acceptance Criteria

- [x] Optional baseline checks run through a single script wrapper.
- [x] Baseline wrapper has consistent output and explicit exit behavior.
- [x] `make help` no longer repeats duplicated sections.
- [x] `make nan-health` works on feature branches without failing the whole target in non-strict mode.
- [x] Strict mode is available when needed (`NAN_BASELINE_STRICT=1`).

## Validation Evidence

```bash
make help
make nan-health
make nan-skills
```

Observed:
- `make help` shows a deduplicated command list.
- `make nan-health` completes and logs warnings instead of failing on branch-specific `nan-update-check` lookup in non-strict mode.
- `make nan-skills` lists baseline skills when available.

## Risk and Rollback

- Risk level: Low
- Rollback: revert commit `f142f92` if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Improved Makefile help text formatting and consistency
  - Refactored build environment baseline checks workflow
  - Enhanced CI/CD automation for dependency management

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanlabs/aws-glue-etl-boilerplate/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->