### PR TITLE
chore: harden helper scripts

### DIFF
--- a/scripts/build-glue-wheels.sh
+++ b/scripts/build-glue-wheels.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # 🚀 AWS Glue Optimized Wheel Builder
 # Creates uber wheels optimized for AWS Glue 5.0 following AWS best practices
@@ -73,22 +73,47 @@ while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
     -r | --requirements)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         REQUIREMENTS_FILE="$2"
         shift 2
         ;;
     -o | --wheel-output)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         FINAL_WHEEL_OUTPUT_DIRECTORY="$2"
         shift 2
         ;;
     -n | --name)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         PACKAGE_NAME="$2"
         shift 2
         ;;
     -v | --version)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         PACKAGE_VERSION="$2"
         shift 2
         ;;
     -g | --glue-version)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         GLUE_VERSION="$2"
         shift 2
         ;;

--- a/scripts/deploy-code-registry.sh
+++ b/scripts/deploy-code-registry.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # 🚀 Code Registry Deployment Script
 # Deploys code artifacts to the Code Registry S3 bucket using AWS profile (local) or OIDC (GitHub Actions)
@@ -93,18 +93,38 @@ while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
     -p | --profile)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         AWS_PROFILE="$2"
         shift 2
         ;;
     -r | --region)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         AWS_REGION="$2"
         shift 2
         ;;
     -b | --bucket)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         CODE_REGISTRY_BUCKET="$2"
         shift 2
         ;;
     -t | --target)
+        if [[ $# -lt 2 ]]; then
+            print_error "Missing value for $1"
+            show_help
+            exit 1
+        fi
         TARGET="$2"
         shift 2
         ;;

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Check for required tools
 if ! command -v pipenv >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

Hardens helper shell scripts by enabling strict mode and adding explicit missing
argument handling for options that require values.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] CI / tooling change

## How Has This Been Tested?

- [x] Ran `bash -n scripts/package.sh scripts/build-glue-wheels.sh scripts/deploy-code-registry.sh`.
- [x] Verified `./scripts/build-glue-wheels.sh -r` exits with a clear missing-value error.
- [x] Verified `./scripts/deploy-code-registry.sh -p` exits with a clear missing-value error.
- [x] Reviewed by `nanlabs-code-reviewer`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
