### PR TITLE
docs: clarify DevContainer onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,22 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for more details.
 
 ## Quick Start
 
-### 1. Clone and bootstrap
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/aws-glue-etl-boilerplate.git
 cd aws-glue-etl-boilerplate
+```
+
+### 2. Open the project in a Dev Container
+
+This project only supports development inside a Dev Container.
+
+Open the project in VS Code and select **Reopen in Container** before running any `make` commands.
+
+### 3. Bootstrap the project
+
+```bash
 make bootstrap
 ```
 
@@ -100,7 +111,7 @@ make nan-health
 make nan-skills
 ```
 
-### 2. Set up environment variables
+### 4. Set up environment variables
 
 ```bash
 cp .env.example .env
@@ -122,7 +133,7 @@ Key variables (see [docs/ENVIRONMENT_VARIABLES.md](docs/ENVIRONMENT_VARIABLES.md
 | `API_BASE_URL` | `https://jsonplaceholder.typicode.com` | Base URL for public API source |
 | `API_ENDPOINT` | `/posts` | Endpoint path |
 
-### 3. Start the local infrastructure
+### 5. Start the local infrastructure
 
 ```bash
 # Starts LocalStack (S3, Glue, SecretsManager) + SFTP server

--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ git clone https://github.com/your-org/aws-glue-etl-boilerplate.git
 cd aws-glue-etl-boilerplate
 ```
 
-### 2. Open the project in a Dev Container
+### 2. Open the project in a Dev Container (Recommended)
 
-This project only supports development inside a Dev Container.
+It is recommended to open the project in the Dev Container before running any `make` commands.
 
-Open the project in VS Code and select **Reopen in Container** before running any `make` commands.
+Open the project in VS Code and select **Reopen in Container** for the recommended development environment.
+
+If you are not using a Dev Container, you can still follow the documented local setup instructions below where applicable.
 
 ### 3. Bootstrap the project
 


### PR DESCRIPTION
## Summary

Updated the README Quick Start section to align with the Makefile onboarding guidance.

Issue: Fixes #70

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Dependency update

## Validation Evidence

Reviewed the updated README to ensure the Quick Start instructions now match the Makefile onboarding guidance.

Validation performed:
- Confirmed the README clearly instructs users to open the project in a Dev Container before running `make` commands.
- Confirmed the README and Makefile onboarding instructions no longer conflict.

## Risk and Rollback

- Risk level: Low
- Rollback plan: Revert the README changes if any issues are identified.

## Checklist

- [x] Scope is focused and minimal
- [ ] Tests and/or checks relevant to this change were executed
- [x] Docs were updated when behavior changed
- [x] No secrets or sensitive data were added
- [x] I verified spelling and basic formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start instructions with a clearer, reordered onboarding sequence.
  * Separated repository cloning from bootstrapping, renumbered subsequent setup steps, and added a dedicated step for opening the project in a Dev Container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->