### PR TITLE
docs: add contributor-friendly local development walkthrough

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,14 +1,53 @@
 # Development Guide
 
+## First contribution walkthrough
+
+This guide provides a minimal path for first-time contributors to validate the project locally.
+
+
+
+You can complete the steps below without AWS credentials or access to private infrastructure.
+
+### Option 1: Use the DevContainer (recommended)
+
+If you use VS Code, open the repository and select **Reopen in Container** when prompted. The DevContainer provides a preconfigured development environment with the required tooling.
+
+### Option 2: Local environment
+
+If you prefer not to use the DevContainer, make sure the project prerequisites are installed before continuing.
+
 ## Recommended local flow
+
+### 1. Bootstrap the project
+
+Run:
 
 ```bash
 make bootstrap
+```
+
+This command prepares the local development environment and installs the required dependencies.
+
+### 2. Validate the environment
+
+```bash
 make check-env
+```
+
+### 3. Run quality checks
+
+```bash
 make lint
 make type-check
+```
+
+### 4. Run unit tests
+
+```bash
 make test-unit
 ```
+
+Unit tests can be executed locally and do not require AWS credentials.
 
 Optional NaNLABS commands (if available):
 
@@ -20,13 +59,21 @@ make nan-skills
 ## Troubleshooting optional baseline checks
 
 - `nan-* command not found`:
-	install or update your NaNLABS workstation baseline, or continue with required project checks.
+  install or update your NaNLABS workstation baseline, or continue with required project checks.
 - `nan-doctor` reports non-compliant:
-	fix the reported dependencies and rerun `make nan-health`.
+  fix the reported dependencies and rerun `make nan-health`.
 - Running in external/non-NaNLABS environments:
-	`make check-env` and `make nan-health` are safe and will skip optional commands when unavailable.
+  `make check-env` and `make nan-health` are safe and will skip optional commands when unavailable.
 
-## Local run examples
+## Example local ETL flow
+
+A minimal local validation path is:
+
+```text
+Raw → Bronze → Silver → Gold
+```
+
+Run the jobs in order:
 
 ```bash
 make run-raw DATA_SOURCE=public_api ENTITY_TYPE=posts

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,9 +16,15 @@ If you are not using the DevContainer, follow the setup instructions in the READ
 
 ## Recommended local flow
 
-### 1. Complete the project setup
+### 1. Bootstrap the project
 
-Follow the setup instructions in the README before continuing with the validation steps below.
+Complete the project setup described in the README.
+
+```bash
+make bootstrap
+```
+
+After the bootstrap completes, continue with the validation steps below.
 
 ### 2. Validate the environment
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,29 +4,21 @@
 
 This guide provides a minimal path for first-time contributors to validate the project locally.
 
-
-
 You can complete the steps below without AWS credentials or access to private infrastructure.
 
 ### Option 1: Use the DevContainer (recommended)
 
-If you use VS Code, open the repository and select **Reopen in Container** when prompted. The DevContainer provides a preconfigured development environment with the required tooling.
+Follow the DevContainer workflow described in the README before continuing.
 
 ### Option 2: Local environment
 
-If you prefer not to use the DevContainer, make sure the project prerequisites are installed before continuing.
+If you are not using the DevContainer, follow the setup instructions in the README before continuing.
 
 ## Recommended local flow
 
-### 1. Bootstrap the project
+### 1. Complete the project setup
 
-Run:
-
-```bash
-make bootstrap
-```
-
-This command prepares the local development environment and installs the required dependencies.
+Follow the setup instructions in the README before continuing with the validation steps below.
 
 ### 2. Validate the environment
 
@@ -59,7 +51,7 @@ make nan-skills
 ## Troubleshooting optional baseline checks
 
 - `nan-* command not found`:
-  install or update your NaNLABS workstation baseline, or continue with required project checks.
+  install or update your NaNLABS workstation baseline, or continue with the required project checks.
 - `nan-doctor` reports non-compliant:
   fix the reported dependencies and rerun `make nan-health`.
 - Running in external/non-NaNLABS environments:


### PR DESCRIPTION
## Summary

Adds a concise local development walkthrough for first-time contributors.

### Changes

- Added a first contribution walkthrough
- Explained `make bootstrap`
- Explained `make test-unit`
- Added DevContainer guidance
- Documented a minimal Raw → Bronze → Silver → Gold local workflow
- Clarified that AWS credentials or private infrastructure are not required.

### Validation

- Documentation reviewed
- Follows the existing Makefile workflow
- No AWS credentials required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added a “first contribution” walkthrough with an explicit local validation sequence (setup → environment checks → quality checks → unit tests).
  * Included concrete `make` commands for linting, type-checking, and unit tests.
  * Clarified that local validation can run without AWS credentials.
  * Updated troubleshooting guidance, including safe skipping of optional `nan-*` steps in non-standard environments.
  * Added an example local ETL flow (Raw → Bronze → Silver → Gold) with “run jobs in order” instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Closes #64